### PR TITLE
Fix sethome command

### DIFF
--- a/MultipleHomes/Commands/SetHomeCommand.cs
+++ b/MultipleHomes/Commands/SetHomeCommand.cs
@@ -35,7 +35,7 @@ namespace ShimmyMySherbet.MultipleHomes.Commands
                 int max = plugin.GetMaxHomes(player);
                 int count = plugin.GetPlayerHomeCount(player);
 
-                if (max >= count)
+                if (count >= max)
                 {
                     UnturnedChat.Say(caller, $"Sorry, but you have reached the max amount of homes: {count}/{max}");
                     return;

--- a/MultipleHomes/Commands/SetHomeCommand.cs
+++ b/MultipleHomes/Commands/SetHomeCommand.cs
@@ -35,6 +35,7 @@ namespace ShimmyMySherbet.MultipleHomes.Commands
                 int max = plugin.GetMaxHomes(player);
                 int count = plugin.GetPlayerHomeCount(player);
 
+                //Fixes by PedroKaleb!
                 if (count >= max)
                 {
                     UnturnedChat.Say(caller, $"Sorry, but you have reached the max amount of homes: {count}/{max}");


### PR DESCRIPTION
Changed order of if statment
because max still ever greather than
count an this dont let for sethomes

[Issue reference](https://github.com/ShimmyMySherbet/MultipleHomes/issues/1)

Previously
```cs
if (max >= count)
{
  UnturnedChat.Say(caller, $"Sorry, but you have reached the max amount of homes: {count}/{max}");
  return;
}
```

Now
```cs
if (count >= max)
{
  UnturnedChat.Say(caller, $"Sorry, but you have reached the max amount of homes: {count}/{max}");
  return;
}
```



